### PR TITLE
Custom message listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ A brief overview over the most important classes and how to use them.
 ### Tuio Client
 The Tuio client class is the entry point for the communication between the client application and a TUIO sender. They hold a reference to a TuioReceiver (which can be UDP or Websocket receiver).
 
+By default, the `Processor` classes add `MessageListeners` for the currently supported Tuio profiles (see above for a list of the supported profiles). But it is also possible to register for your own custom message profile by calling `AddMessageListener` on the `TuioClient`. Here you are not limited to the Tuio profiles. You can register to every OSC message format your Tuio sender supports.
+
+```csharp
+var tuioClient = new TuioClient(TuioConnectionType.UDP);
+tuioClient.AddMessageListener(new MessageListener("/my/profile/example", OnMessage);
+    
+private void OnMessage(OSCMessage message)
+{
+    // Do something with the message
+}        
+```
+
 ### Tuio Processors
 Tuio processors are responsible for parsing tuio messages. There are two types of processors, one for TUIO 1.1 and one for TUIO 2.0. They get a client object and can listen to specific messages by register callback methods for them. In the current implementation the TUIO processors listen to the following message profiles.
 

--- a/src/TuioNet/Common/TuioClient.cs
+++ b/src/TuioNet/Common/TuioClient.cs
@@ -54,5 +54,14 @@ namespace TuioNet.Common
                 _tuioReceiver.AddMessageListener(listener);
             }
         }
+
+        /// <summary>
+        /// Adds a listener to react on a custom profile.
+        /// </summary>
+        /// <param name="listener">The MessageListener which contains the name of the profile and the callback method which gets invoked for the given profile.</param>
+        public void AddMessageListener(MessageListener listener)
+        {
+            _tuioReceiver.AddMessageListener(listener);
+        }
     }
 }

--- a/src/TuioNet/Common/TuioClient.cs
+++ b/src/TuioNet/Common/TuioClient.cs
@@ -63,5 +63,14 @@ namespace TuioNet.Common
         {
             _tuioReceiver.AddMessageListener(listener);
         }
+
+        /// <summary>
+        /// Remove a listener from a given profile.
+        /// </summary>
+        /// <param name="messageProfile">The TUIO profile the listener should be removed from.</param>
+        public void RemoveMessageListener(string messageProfile)
+        {
+            _tuioReceiver.RemoveMessageListener(messageProfile);
+        }
     }
 }

--- a/src/TuioNet/Common/TuioClient.cs
+++ b/src/TuioNet/Common/TuioClient.cs
@@ -51,7 +51,7 @@ namespace TuioNet.Common
         {
             foreach (var listener in listeners)
             {
-                _tuioReceiver.AddMessageListener(listener);
+                AddMessageListener(listener);
             }
         }
 

--- a/src/TuioNet/Common/TuioClient.cs
+++ b/src/TuioNet/Common/TuioClient.cs
@@ -51,7 +51,7 @@ namespace TuioNet.Common
         {
             foreach (var listener in listeners)
             {
-                _tuioReceiver.AddMessageListener(listener.MessageProfile, listener.Callback);
+                _tuioReceiver.AddMessageListener(listener);
             }
         }
     }

--- a/src/TuioNet/Common/TuioReceiver.cs
+++ b/src/TuioNet/Common/TuioReceiver.cs
@@ -106,18 +106,18 @@ namespace TuioNet.Common
         /// <summary>
         /// Adds a listener for a given TUIO profile.
         /// </summary>
-        /// <param name="messageProfile">The TUIO profile to listen to.</param>
-        /// <param name="listener">The callback method which gets invoked for the given adress.</param>
+        /// <param name="listener">The MessageListener which contains the name of the profile and the callback method which gets invoked for the given adress.</param>
         /// <example>
         /// <code>AddMessageListener("/tuio/2Dobj", OnCallback)</code>
         /// </example>
-        internal void AddMessageListener(string messageProfile, Action<OSCMessage> listener)
+        internal void AddMessageListener(MessageListener listener)
         {
-            if (!_messageListeners.ContainsKey(messageProfile))
+            var profile = listener.MessageProfile;
+            if (!_messageListeners.ContainsKey(profile))
             {
-                _messageListeners[messageProfile] = new List<Action<OSCMessage>>();
+                _messageListeners[profile] = new List<Action<OSCMessage>>();
             }
-            _messageListeners[messageProfile].Add(listener);
+            _messageListeners[profile].Add(listener.Callback);
         }
         
         /// <summary>

--- a/src/TuioNet/Common/TuioReceiver.cs
+++ b/src/TuioNet/Common/TuioReceiver.cs
@@ -106,7 +106,7 @@ namespace TuioNet.Common
         /// <summary>
         /// Adds a listener for a given TUIO profile.
         /// </summary>
-        /// <param name="listener">The MessageListener which contains the name of the profile and the callback method which gets invoked for the given adress.</param>
+        /// <param name="listener">The MessageListener which contains the name of the profile and the callback method which gets invoked for the given profile.</param>
         /// <example>
         /// <code>AddMessageListener("/tuio/2Dobj", OnCallback)</code>
         /// </example>


### PR DESCRIPTION
# Custom Message Listener

This PR introduces the possibility to register callbacks on custom osc message profiles. This makes it possible to implement more tuio profiles or subscribe to custom message profiles you implemented on the tuio sender side.

## Changes
- Add a public methods `AddMessageListener` and `RemoveMessageListener` in the `TuioClient` class.
- Update Readme with simple example